### PR TITLE
Update form to reflect changes in regular income/expense table schema

### DIFF
--- a/app/(protected)/transactions/recurring/new/actions.ts
+++ b/app/(protected)/transactions/recurring/new/actions.ts
@@ -16,6 +16,8 @@ export async function createRecurringTransactionAction(
 	const type = formData.get("type") as TransactionType;
 	const dayOfMonth = Number.parseInt(formData.get("dayOfMonth") as string, 10);
 	const description = formData.get("description") as string;
+	// default_amountはamountと同じ値で初期化
+	const defaultAmount = amount;
 
 	if (!accountId) {
 		return { error: "口座を選択してください" };
@@ -42,6 +44,7 @@ export async function createRecurringTransactionAction(
 			accountId,
 			name,
 			amount,
+			defaultAmount,
 			type,
 			dayOfMonth,
 			description,

--- a/utils/supabase/recurring-transactions.ts
+++ b/utils/supabase/recurring-transactions.ts
@@ -65,6 +65,7 @@ export async function createRecurringTransaction(
 	accountId: string,
 	name: string,
 	amount: number,
+	defaultAmount: number,
 	type: TransactionType,
 	dayOfMonth: number | string,
 	description?: string,
@@ -84,6 +85,7 @@ export async function createRecurringTransaction(
 		accountId,
 		name,
 		amount,
+		defaultAmount,
 		type,
 		dayOfMonth,
 		description,
@@ -96,6 +98,7 @@ export async function createRecurringTransaction(
 				account_id: validatedData.accountId,
 				name: validatedData.name,
 				amount: validatedData.amount,
+				default_amount: validatedData.defaultAmount,
 				type: validatedData.type,
 				day_of_month: validatedData.dayOfMonth, // バリデーション済みの整数値
 				description: validatedData.description || null,

--- a/utils/validators/recurring-transaction.ts
+++ b/utils/validators/recurring-transaction.ts
@@ -31,6 +31,7 @@ export const createTransactionSchema = object({
 	accountId: string("口座IDは必須です"),
 	name: string("名前は必須です"),
 	amount: pipe(number(), minValue(0, "金額は正の数値で入力してください")),
+	defaultAmount: pipe(number(), minValue(0, "初期金額は正の数値で入力してください")),
 	type: transactionTypeSchema,
 	dayOfMonth: dayOfMonthSchema,
 	description: optional(string()),
@@ -42,6 +43,9 @@ export const updateTransactionSchema = object({
 	amount: optional(
 		pipe(number(), minValue(0, "金額は正の数値で入力してください")),
 	),
+	defaultAmount: optional(
+		pipe(number(), minValue(0, "初期金額は正の数値で入力してください")),
+	),
 	type: optional(transactionTypeSchema),
 	dayOfMonth: optional(dayOfMonthSchema),
 	description: optional(string()),
@@ -52,6 +56,7 @@ export type CreateTransactionInput = {
 	accountId: string;
 	name: string;
 	amount: number;
+	defaultAmount: number;
 	type: TransactionType;
 	dayOfMonth: number | string;
 	description?: string;
@@ -62,6 +67,7 @@ export type CreateTransactionOutput = {
 	accountId: string;
 	name: string;
 	amount: number;
+	defaultAmount: number;
 	type: TransactionType;
 	dayOfMonth: number;
 	description?: string;
@@ -71,6 +77,7 @@ export type CreateTransactionOutput = {
 export type UpdateTransactionInput = {
 	name?: string;
 	amount?: number;
+	defaultAmount?: number;
 	type?: TransactionType;
 	dayOfMonth?: number | string;
 	description?: string | null;
@@ -80,6 +87,7 @@ export type UpdateTransactionInput = {
 export type UpdateTransactionOutput = {
 	name?: string;
 	amount?: number;
+	defaultAmount?: number;
 	type?: TransactionType;
 	dayOfMonth?: number;
 	description?: string;

--- a/utils/validators/recurring-transaction.ts
+++ b/utils/validators/recurring-transaction.ts
@@ -31,7 +31,10 @@ export const createTransactionSchema = object({
 	accountId: string("口座IDは必須です"),
 	name: string("名前は必須です"),
 	amount: pipe(number(), minValue(0, "金額は正の数値で入力してください")),
-	defaultAmount: pipe(number(), minValue(0, "初期金額は正の数値で入力してください")),
+	defaultAmount: pipe(
+		number(),
+		minValue(0, "初期金額は正の数値で入力してください"),
+	),
 	type: transactionTypeSchema,
 	dayOfMonth: dayOfMonthSchema,
 	description: optional(string()),


### PR DESCRIPTION
This pull request introduces a new `defaultAmount` field to the recurring transaction functionality. The changes ensure that `defaultAmount` is initialized, validated, and passed through all relevant layers of the application, from input validation to database insertion.

### Addition of `defaultAmount` field:

* **Initialization in `createRecurringTransactionAction`:**
  - Added `defaultAmount`, initialized with the same value as `amount`. (`app/(protected)/transactions/recurring/new/actions.ts`, [[1]](diffhunk://#diff-6e9497a51a1b2465d91d66c89163d7ca15bffc954e52fc95b106891b90895444R19-R20) [[2]](diffhunk://#diff-6e9497a51a1b2465d91d66c89163d7ca15bffc954e52fc95b106891b90895444R47)

* **Database interaction in `createRecurringTransaction`:**
  - Updated function to include `defaultAmount` in its parameters and database insertion logic. (`utils/supabase/recurring-transactions.ts`, [[1]](diffhunk://#diff-7f8e9eb94cef4cd84b969dfca9d5482c53fa990d574b721d9c00789c9c07a8fdR68) [[2]](diffhunk://#diff-7f8e9eb94cef4cd84b969dfca9d5482c53fa990d574b721d9c00789c9c07a8fdR88) [[3]](diffhunk://#diff-7f8e9eb94cef4cd84b969dfca9d5482c53fa990d574b721d9c00789c9c07a8fdR101)

* **Validation schema updates:**
  - Added `defaultAmount` to both `createTransactionSchema` and `updateTransactionSchema` with validation rules to ensure it is a positive number. (`utils/validators/recurring-transaction.ts`, [[1]](diffhunk://#diff-03f78c3b10afd86e0908afd1d5821fc7716409cbdbc048d8005a297cb53c0ceaR34) [[2]](diffhunk://#diff-03f78c3b10afd86e0908afd1d5821fc7716409cbdbc048d8005a297cb53c0ceaR46-R48)

* **Type updates:**
  - Included `defaultAmount` in the `CreateTransactionInput`, `CreateTransactionOutput`, `UpdateTransactionInput`, and `UpdateTransactionOutput` types. (`utils/validators/recurring-transaction.ts`, [[1]](diffhunk://#diff-03f78c3b10afd86e0908afd1d5821fc7716409cbdbc048d8005a297cb53c0ceaR59) [[2]](diffhunk://#diff-03f78c3b10afd86e0908afd1d5821fc7716409cbdbc048d8005a297cb53c0ceaR70) [[3]](diffhunk://#diff-03f78c3b10afd86e0908afd1d5821fc7716409cbdbc048d8005a297cb53c0ceaR80) [[4]](diffhunk://#diff-03f78c3b10afd86e0908afd1d5821fc7716409cbdbc048d8005a297cb53c0ceaR90)