### PR TITLE
chore: remove hardcoded port from dev script command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"scripts": {
-		"dev": "next dev -p 3010",
+		"dev": "next dev",
 		"build": "next build",
 		"start": "next start",
 		"lint": "biome lint --write .",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change removes the custom port specification (`-p 3010`) from the `dev` script, allowing the default port to be used instead.