### PR TITLE
fix: use npx to run claude-code in GitHub Actions

### DIFF
--- a/.github/workflows/claude-code-auto.yml
+++ b/.github/workflows/claude-code-auto.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         
-      - name: Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code
-        
       - name: Run Claude Code with Issue content
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -45,8 +42,8 @@ jobs:
           echo "Issue: $issue_title" > /tmp/issue_request.txt
           echo "Description: $issue_body" >> /tmp/issue_request.txt
           
-          # Run Claude Code with the issue content
-          claude-code "$issue_title: $issue_body"
+          # Run Claude Code with the issue content using npx
+          npx @anthropic-ai/claude-code "$issue_title: $issue_body"
           
       - name: Commit changes if any
         run: |


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workflow for Claude Code automation
- Use npx to run claude-code to avoid PATH issues

## Problem
The GitHub Actions workflow was failing with "claude-code: command not found" error because the globally installed npm package wasn't in the PATH.

## Solution
Using `npx @anthropic-ai/claude-code` instead of installing globally and running `claude-code` directly. This ensures the command can be found and executed properly.

This change:
1. Removes the global installation step
2. Uses npx to run claude-code directly

Fixes the error shown in the Actions run.