### PR TITLE
データベーススキーマ: 口座間送金機能のテーブル拡張

### DIFF
--- a/supabase/migrations/20250624_add_transfer_columns.sql
+++ b/supabase/migrations/20250624_add_transfer_columns.sql
@@ -1,0 +1,51 @@
+-- 口座間送金機能のためのカラム追加
+-- one_time_transactions テーブルに送金関連カラムを追加
+ALTER TABLE one_time_transactions 
+ADD COLUMN is_transfer BOOLEAN DEFAULT FALSE NOT NULL,
+ADD COLUMN destination_account_id UUID REFERENCES accounts(id) ON DELETE CASCADE,
+ADD COLUMN transfer_pair_id UUID;
+
+-- recurring_transactions テーブルに送金関連カラムを追加
+ALTER TABLE recurring_transactions 
+ADD COLUMN is_transfer BOOLEAN DEFAULT FALSE NOT NULL,
+ADD COLUMN destination_account_id UUID REFERENCES accounts(id) ON DELETE CASCADE,
+ADD COLUMN transfer_pair_id UUID;
+
+-- 送金ペアの整合性を保つための制約を追加
+-- 送金の場合、destination_account_id は必須
+ALTER TABLE one_time_transactions 
+ADD CONSTRAINT check_transfer_destination 
+CHECK (
+  (is_transfer = TRUE AND destination_account_id IS NOT NULL) OR
+  (is_transfer = FALSE AND destination_account_id IS NULL)
+);
+
+ALTER TABLE recurring_transactions 
+ADD CONSTRAINT check_transfer_destination 
+CHECK (
+  (is_transfer = TRUE AND destination_account_id IS NOT NULL) OR
+  (is_transfer = FALSE AND destination_account_id IS NULL)
+);
+
+-- 送金の場合、送金元と送金先の口座は異なる必要がある
+ALTER TABLE one_time_transactions 
+ADD CONSTRAINT check_different_accounts 
+CHECK (
+  (is_transfer = FALSE) OR 
+  (is_transfer = TRUE AND account_id != destination_account_id)
+);
+
+ALTER TABLE recurring_transactions 
+ADD CONSTRAINT check_different_accounts 
+CHECK (
+  (is_transfer = FALSE) OR 
+  (is_transfer = TRUE AND account_id != destination_account_id)
+);
+
+-- 送金ペアID用のインデックスを追加（パフォーマンス向上のため）
+CREATE INDEX idx_one_time_transactions_transfer_pair ON one_time_transactions(transfer_pair_id);
+CREATE INDEX idx_recurring_transactions_transfer_pair ON recurring_transactions(transfer_pair_id);
+
+-- 送金先口座ID用のインデックスを追加
+CREATE INDEX idx_one_time_transactions_destination_account ON one_time_transactions(destination_account_id);
+CREATE INDEX idx_recurring_transactions_destination_account ON recurring_transactions(destination_account_id);

--- a/types/database.ts
+++ b/types/database.ts
@@ -20,6 +20,9 @@ export type RecurringTransaction = {
 	name: string;
 	description: string | null;
 	day_of_month: number;
+	is_transfer: boolean;
+	destination_account_id: string | null;
+	transfer_pair_id: string | null;
 	created_at: string;
 	updated_at: string;
 };
@@ -43,6 +46,9 @@ export type OneTimeTransaction = {
 	name: string;
 	description: string | null;
 	transaction_date: string;
+	is_transfer: boolean;
+	destination_account_id: string | null;
+	transfer_pair_id: string | null;
 	created_at: string;
 	updated_at: string;
 };
@@ -53,4 +59,10 @@ export type SavingsPrediction = {
 	period: PredictionPeriod;
 	amount: number;
 	date: string;
+};
+
+// 送金ペア用の型定義
+export type TransferPair = {
+	sourceTransaction: OneTimeTransaction | RecurringTransaction;
+	destinationTransaction: OneTimeTransaction | RecurringTransaction;
 };


### PR DESCRIPTION
## 概要
口座間送金機能を実装するためのデータベーススキーマ拡張を行いました。

## 変更内容

### データベースマイグレーション
- `one_time_transactions`テーブルに送金関連カラムを追加:
  - `is_transfer`: 送金トランザクションかどうかのフラグ
  - `destination_account_id`: 送金先口座のID
  - `transfer_pair_id`: 送金ペアを識別するUUID

- `recurring_transactions`テーブルに同様のカラムを追加

### データ整合性の確保
- 送金時は送金先口座IDが必須となる制約を追加
- 送金元と送金先が同じ口座になることを防ぐ制約を追加
- パフォーマンス向上のためのインデックスを追加

### 型定義の更新
- `OneTimeTransaction`と`RecurringTransaction`型に新しいフィールドを追加
- 送金ペア用の`TransferPair`型を追加

## テスト手順
1. マイグレーションが正常に適用されること
2. 既存のトランザクションデータに影響がないこと
3. 新しい制約が正しく動作すること

## 次のステップ
- バックエンドロジックの実装
- フロントエンドへの送金機能追加

🤖 Generated with [Claude Code](https://claude.ai/code)