### PR TITLE
バックエンド: 口座間送金処理の実装

### DIFF
--- a/app/(protected)/transactions/one-time/new/action.ts
+++ b/app/(protected)/transactions/one-time/new/action.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import type { TransactionType } from "@/types/database";
-import { createOneTimeTransaction } from "@/utils/supabase/one-time-transactions";
+import {
+	createOneTimeTransaction,
+	createOneTimeTransfer,
+} from "@/utils/supabase/one-time-transactions";
 
 type ActionState = { error?: string; success?: string };
 
@@ -11,6 +14,8 @@ export async function createOneTimeTransactionAction(
 	formData: FormData,
 ): Promise<ActionState> {
 	const accountId = formData.get("accountId") as string;
+	const destinationAccountId = formData.get("destinationAccountId") as string;
+	const isTransfer = formData.get("isTransfer") === "true";
 	const name = formData.get("name") as string;
 	const amount = Number.parseFloat(formData.get("amount") as string);
 	const type = formData.get("type") as TransactionType;
@@ -29,7 +34,7 @@ export async function createOneTimeTransactionAction(
 		return { error: "金額は正の数値で入力してください" };
 	}
 
-	if (type !== "income" && type !== "expense") {
+	if (!isTransfer && type !== "income" && type !== "expense") {
 		return { error: "種別は収入または支出を選択してください" };
 	}
 
@@ -37,7 +42,28 @@ export async function createOneTimeTransactionAction(
 		return { error: "有効な日付を入力してください" };
 	}
 
+	// 送金の場合の追加バリデーション
+	if (isTransfer) {
+		if (!destinationAccountId) {
+			return { error: "送金先口座を選択してください" };
+		}
+		if (accountId === destinationAccountId) {
+			return { error: "送金元と送金先は異なる口座である必要があります" };
+		}
+	}
+
 	try {
+		if (isTransfer) {
+			await createOneTimeTransfer(
+				accountId,
+				destinationAccountId,
+				name,
+				amount,
+				transactionDate,
+				description,
+			);
+			return { success: "口座間送金が正常に作成されました" };
+		}
 		await createOneTimeTransaction(
 			accountId,
 			name,
@@ -49,6 +75,6 @@ export async function createOneTimeTransactionAction(
 		return { success: "臨時収支が正常に作成されました" };
 	} catch (error) {
 		console.error("Error creating one-time transaction:", error);
-		return { error: "臨時収支の作成に失敗しました" };
+		return { error: "取引の作成に失敗しました" };
 	}
 }

--- a/supabase/migrations/20250624_add_transfer_functions.sql
+++ b/supabase/migrations/20250624_add_transfer_functions.sql
@@ -1,0 +1,180 @@
+-- 一時的取引の送金を作成するストアドプロシージャ
+CREATE OR REPLACE FUNCTION create_one_time_transfer(
+    p_user_id UUID,
+    p_source_account_id UUID,
+    p_destination_account_id UUID,
+    p_name TEXT,
+    p_amount DECIMAL(12, 2),
+    p_transaction_date DATE,
+    p_description TEXT DEFAULT NULL,
+    p_transfer_pair_id UUID DEFAULT NULL
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_transfer_pair_id UUID;
+    v_source_transaction one_time_transactions;
+    v_destination_transaction one_time_transactions;
+BEGIN
+    -- 送金ペアIDを生成（渡されない場合）
+    IF p_transfer_pair_id IS NULL THEN
+        v_transfer_pair_id := gen_random_uuid();
+    ELSE
+        v_transfer_pair_id := p_transfer_pair_id;
+    END IF;
+
+    -- 送金元口座から支出トランザクションを作成
+    INSERT INTO one_time_transactions (
+        user_id,
+        account_id,
+        amount,
+        type,
+        name,
+        description,
+        transaction_date,
+        is_transfer,
+        destination_account_id,
+        transfer_pair_id
+    ) VALUES (
+        p_user_id,
+        p_source_account_id,
+        p_amount,
+        'expense',
+        p_name,
+        p_description,
+        p_transaction_date,
+        TRUE,
+        p_destination_account_id,
+        v_transfer_pair_id
+    )
+    RETURNING * INTO v_source_transaction;
+
+    -- 送金先口座に収入トランザクションを作成
+    INSERT INTO one_time_transactions (
+        user_id,
+        account_id,
+        amount,
+        type,
+        name,
+        description,
+        transaction_date,
+        is_transfer,
+        destination_account_id,
+        transfer_pair_id
+    ) VALUES (
+        p_user_id,
+        p_destination_account_id,
+        p_amount,
+        'income',
+        p_name,
+        p_description,
+        p_transaction_date,
+        TRUE,
+        p_source_account_id, -- 収入側では送金元を destination_account_id に設定
+        v_transfer_pair_id
+    )
+    RETURNING * INTO v_destination_transaction;
+
+    -- 結果をJSONで返す
+    RETURN json_build_object(
+        'transfer_pair_id', v_transfer_pair_id,
+        'source_transaction', row_to_json(v_source_transaction),
+        'destination_transaction', row_to_json(v_destination_transaction)
+    );
+END;
+$$;
+
+-- 定期取引の送金を作成するストアドプロシージャ
+CREATE OR REPLACE FUNCTION create_recurring_transfer(
+    p_user_id UUID,
+    p_source_account_id UUID,
+    p_destination_account_id UUID,
+    p_name TEXT,
+    p_amount DECIMAL(12, 2),
+    p_default_amount DECIMAL(12, 2),
+    p_day_of_month INTEGER,
+    p_description TEXT DEFAULT NULL,
+    p_transfer_pair_id UUID DEFAULT NULL
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_transfer_pair_id UUID;
+    v_source_transaction recurring_transactions;
+    v_destination_transaction recurring_transactions;
+BEGIN
+    -- 送金ペアIDを生成（渡されない場合）
+    IF p_transfer_pair_id IS NULL THEN
+        v_transfer_pair_id := gen_random_uuid();
+    ELSE
+        v_transfer_pair_id := p_transfer_pair_id;
+    END IF;
+
+    -- 送金元口座から支出トランザクションを作成
+    INSERT INTO recurring_transactions (
+        user_id,
+        account_id,
+        amount,
+        default_amount,
+        type,
+        name,
+        description,
+        day_of_month,
+        is_transfer,
+        destination_account_id,
+        transfer_pair_id
+    ) VALUES (
+        p_user_id,
+        p_source_account_id,
+        p_amount,
+        p_default_amount,
+        'expense',
+        p_name,
+        p_description,
+        p_day_of_month,
+        TRUE,
+        p_destination_account_id,
+        v_transfer_pair_id
+    )
+    RETURNING * INTO v_source_transaction;
+
+    -- 送金先口座に収入トランザクションを作成
+    INSERT INTO recurring_transactions (
+        user_id,
+        account_id,
+        amount,
+        default_amount,
+        type,
+        name,
+        description,
+        day_of_month,
+        is_transfer,
+        destination_account_id,
+        transfer_pair_id
+    ) VALUES (
+        p_user_id,
+        p_destination_account_id,
+        p_amount,
+        p_default_amount,
+        'income',
+        p_name,
+        p_description,
+        p_day_of_month,
+        TRUE,
+        p_source_account_id, -- 収入側では送金元を destination_account_id に設定
+        v_transfer_pair_id
+    )
+    RETURNING * INTO v_destination_transaction;
+
+    -- 結果をJSONで返す
+    RETURN json_build_object(
+        'transfer_pair_id', v_transfer_pair_id,
+        'source_transaction', row_to_json(v_source_transaction),
+        'destination_transaction', row_to_json(v_destination_transaction)
+    );
+END;
+$$;

--- a/utils/supabase/recurring-transactions.ts
+++ b/utils/supabase/recurring-transactions.ts
@@ -103,6 +103,9 @@ export async function createRecurringTransaction(
 				day_of_month: validatedData.dayOfMonth, // バリデーション済みの整数値
 				description: validatedData.description || null,
 				user_id: user.id, // ユーザーIDを設定
+				is_transfer: false,
+				destination_account_id: null,
+				transfer_pair_id: null,
 			},
 		])
 		.select()
@@ -114,6 +117,68 @@ export async function createRecurringTransaction(
 	}
 
 	return data as RecurringTransaction;
+}
+
+/**
+ * 口座間送金を作成する（定期取引）
+ */
+export async function createRecurringTransfer(
+	sourceAccountId: string,
+	destinationAccountId: string,
+	name: string,
+	amount: number,
+	defaultAmount: number,
+	dayOfMonth: number,
+	description?: string,
+): Promise<{
+	sourceTransaction: RecurringTransaction;
+	destinationTransaction: RecurringTransaction;
+}> {
+	const supabase = await createClient();
+
+	// 現在のユーザーIDを取得
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+	if (!user) {
+		throw new Error("ユーザーが認証されていません");
+	}
+
+	// 送金元と送金先が同じ口座でないことを確認
+	if (sourceAccountId === destinationAccountId) {
+		throw new Error("送金元と送金先は異なる口座である必要があります");
+	}
+
+	// 送金ペアIDを生成
+	const transferPairId = crypto.randomUUID();
+
+	// トランザクションを使用して両方の取引を同時に作成
+	const { data, error } = await supabase.rpc("create_recurring_transfer", {
+		p_user_id: user.id,
+		p_source_account_id: sourceAccountId,
+		p_destination_account_id: destinationAccountId,
+		p_name: name,
+		p_amount: amount,
+		p_default_amount: defaultAmount,
+		p_day_of_month: dayOfMonth,
+		p_description: description || null,
+		p_transfer_pair_id: transferPairId,
+	});
+
+	if (error) {
+		console.error("Error creating recurring transfer:", error);
+		throw new Error("定期送金の作成に失敗しました");
+	}
+
+	if (!data) {
+		throw new Error("定期送金データの作成に失敗しました");
+	}
+
+	const sourceTransaction = data.source_transaction as RecurringTransaction;
+	const destinationTransaction =
+		data.destination_transaction as RecurringTransaction;
+
+	return { sourceTransaction, destinationTransaction };
 }
 
 /**


### PR DESCRIPTION
## 概要
口座間送金機能のバックエンドロジックを実装しました。

## 変更内容

### データベースストアドプロシージャ
- `create_one_time_transfer`: 一時的取引での送金処理
- `create_recurring_transfer`: 定期取引での送金処理
- アトミックな操作でペアとなる取引を同時作成

### 新機能の追加
- `createOneTimeTransfer`: 一時的送金作成関数
- `createRecurringTransfer`: 定期送金作成関数
- 送金元（支出）と送金先（収入）のペア取引を自動作成
- `transfer_pair_id`による取引の紐付け

### Server Actions更新
- 一時的取引と定期取引のActionで送金をサポート
- 送金時の追加バリデーション:
  - 送金先口座の必須チェック
  - 送金元と送金先の重複チェック
- 適切なエラーメッセージとレスポンス

### データ整合性
- 送金はアトミック操作で実行
- 送金元と送金先が必ず同じ金額で作成
- データベースレベルでの整合性制約

## テスト手順
1. 送金フラグを有効にした状態でフォーム送信
2. 送金元と送金先で同一金額の取引が作成されること
3. 両方の取引が同じ`transfer_pair_id`を持つこと
4. エラー条件（同一口座選択等）で適切にエラーが発生すること

## 次のステップ
- フロントエンドUI実装
- 送金表示の改善

🤖 Generated with [Claude Code](https://claude.ai/code)