### PR TITLE
feat: redesign accounts page with HeroUI components

### DIFF
--- a/app/(protected)/accounts/_components/sortable-account-list.tsx
+++ b/app/(protected)/accounts/_components/sortable-account-list.tsx
@@ -17,9 +17,12 @@ import {
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { Button } from "@heroui/button";
+import { Card, CardBody, CardHeader } from "@heroui/card";
+import { Chip } from "@heroui/chip";
+import { Divider } from "@heroui/divider";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { Button } from "@/components/button";
 import type { Account } from "@/types/database";
 import { updateAccountOrderAction } from "../actions";
 
@@ -39,32 +42,54 @@ function SortableAccountItem({ account, isSorting }: SortableAccountItemProps) {
 	};
 
 	return (
-		<div
+		<Card
 			ref={setNodeRef}
 			style={style}
 			{...(isSorting ? { ...attributes, ...listeners } : {})}
-			className={`bg-white dark:bg-gray-800 rounded-lg shadow p-6 ${isSorting ? "cursor-move" : ""}`}
+			className={isSorting ? "cursor-move" : ""}
 		>
-			<div className="flex justify-between items-start mb-4">
-				<h2 className="text-xl font-semibold">{account.name}</h2>
-				{!isSorting && (
-					<div className="flex space-x-2">
-						<Button variant="outline" size="sm" asChild>
-							<Link href={`/accounts/${account.id}`}>詳細</Link>
-						</Button>
-						<Button variant="outline" size="sm" asChild>
-							<Link href={`/accounts/${account.id}/edit`}>編集</Link>
-						</Button>
-					</div>
-				)}
-			</div>
-			<p className="text-2xl font-bold mb-2">
-				¥{account.current_balance.toLocaleString()}
-			</p>
-			<p className="text-sm text-gray-500">
-				最終更新: {new Date(account.updated_at).toLocaleDateString()}
-			</p>
-		</div>
+			<CardHeader>
+				<div className="flex justify-between items-start w-full">
+					<h2 className="text-xl font-semibold">{account.name}</h2>
+					{!isSorting && (
+						<div className="flex space-x-2">
+							<Button
+								variant="bordered"
+								size="sm"
+								as={Link}
+								href={`/accounts/${account.id}`}
+							>
+								詳細
+							</Button>
+							<Button
+								variant="bordered"
+								size="sm"
+								as={Link}
+								href={`/accounts/${account.id}/edit`}
+							>
+								編集
+							</Button>
+						</div>
+					)}
+				</div>
+			</CardHeader>
+			<CardBody>
+				<div className="space-y-3">
+					<Chip
+						color={account.current_balance >= 0 ? "success" : "danger"}
+						variant="flat"
+						size="lg"
+						className="text-2xl font-bold px-4 py-2"
+					>
+						¥{account.current_balance.toLocaleString()}
+					</Chip>
+					<Divider />
+					<p className="text-sm text-default-500">
+						最終更新: {new Date(account.updated_at).toLocaleDateString()}
+					</p>
+				</div>
+			</CardBody>
+		</Card>
 	);
 }
 
@@ -132,7 +157,8 @@ export default function SortableAccountList({
 						<Button
 							onClick={saveSortOrder}
 							disabled={isSubmitting}
-							variant="default"
+							color="primary"
+							isLoading={isSubmitting}
 						>
 							{isSubmitting ? "保存中..." : "並び順を保存"}
 						</Button>
@@ -141,14 +167,14 @@ export default function SortableAccountList({
 								setIsSorting(false);
 								setAccounts(initialAccounts);
 							}}
-							variant="outline"
+							variant="bordered"
 							disabled={isSubmitting}
 						>
 							キャンセル
 						</Button>
 					</div>
 				) : (
-					<Button onClick={() => setIsSorting(true)} variant="outline">
+					<Button onClick={() => setIsSorting(true)} variant="bordered">
 						並び替え
 					</Button>
 				)}
@@ -186,12 +212,14 @@ export default function SortableAccountList({
 					)}
 				</div>
 			) : (
-				<div className="bg-white dark:bg-gray-800 rounded-lg shadow p-8 text-center">
-					<p className="text-lg mb-4">口座がまだ登録されていません</p>
-					<Button asChild>
-						<Link href="/accounts/new">最初の口座を追加する</Link>
-					</Button>
-				</div>
+				<Card>
+					<CardBody className="text-center py-8">
+						<p className="text-lg mb-4">口座がまだ登録されていません</p>
+						<Button color="primary" as={Link} href="/accounts/new">
+							最初の口座を追加する
+						</Button>
+					</CardBody>
+				</Card>
 			)}
 		</div>
 	);

--- a/app/(protected)/accounts/_components/sortable-account-list.tsx
+++ b/app/(protected)/accounts/_components/sortable-account-list.tsx
@@ -76,7 +76,7 @@ function SortableAccountItem({ account, isSorting }: SortableAccountItemProps) {
 			<CardBody>
 				<div className="space-y-3">
 					<Chip
-						color={account.current_balance >= 0 ? "success" : "danger"}
+						color={account.current_balance < 0 ? "danger" : "default"}
 						variant="flat"
 						size="lg"
 						className="text-2xl font-bold px-4 py-2"

--- a/app/(protected)/accounts/page.tsx
+++ b/app/(protected)/accounts/page.tsx
@@ -1,5 +1,6 @@
+import { Button } from "@heroui/button";
+import { Card, CardBody, CardHeader } from "@heroui/card";
 import Link from "next/link";
-import { Button } from "@/components/button";
 import { getUserAccounts } from "@/utils/supabase/accounts";
 import SortableAccountList from "./_components/sortable-account-list";
 
@@ -9,15 +10,20 @@ export default async function AccountsPage() {
 
 	return (
 		<div className="space-y-8">
-			<div className="flex justify-between items-center">
-				<h1 className="text-2xl font-bold">口座管理</h1>
-				<Button asChild>
-					<Link href="/accounts/new">新規口座を追加</Link>
-				</Button>
-			</div>
-
-			{/* クライアントコンポーネントに口座リストを渡す */}
-			<SortableAccountList initialAccounts={accounts} />
+			<Card>
+				<CardHeader>
+					<div className="flex justify-between items-center w-full">
+						<h1 className="text-2xl font-bold">口座管理</h1>
+						<Button color="primary" as={Link} href="/accounts/new">
+							新規口座を追加
+						</Button>
+					</div>
+				</CardHeader>
+				<CardBody>
+					{/* クライアントコンポーネントに口座リストを渡す */}
+					<SortableAccountList initialAccounts={accounts} />
+				</CardBody>
+			</Card>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Replace custom buttons with HeroUI Button components for consistency
- Convert account cards to HeroUI Card components with proper CardHeader/CardBody structure
- Add Chip component for balance display with color coding (red for negative, default for positive)
- Use Divider for better visual separation between sections
- Improve empty state with HeroUI Card layout
- Add loading states with isLoading prop on save button
- Update button variants to use HeroUI conventions (bordered, primary)

## Test plan
- [x] Verify accounts page loads correctly
- [x] Check that account cards display properly with new Card components
- [x] Confirm balance chips show correct colors (red for negative, default for positive)
- [x] Test drag and drop functionality still works
- [x] Verify save/cancel buttons work properly with loading states
- [x] Check empty state displays correctly
- [x] Run lint and type checks

🤖 Generated with [Claude Code](https://claude.ai/code)