### PR TITLE
Synchronize year and month navigation

### DIFF
--- a/app/(protected)/summary/_components/month-navigation-buttons.tsx
+++ b/app/(protected)/summary/_components/month-navigation-buttons.tsx
@@ -43,14 +43,12 @@ export function MonthNavigationButtons({
 	>(null);
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-	// Generate year-month options (3 years back, 1 year forward)
+	// Generate options ensuring the currently selected year stays in range
 	const currentActualYear = new Date().getFullYear();
+	const minYear = Math.min(currentActualYear - 3, currentYear - 3);
+	const maxYear = Math.max(currentActualYear + 1, currentYear + 1);
 	const yearMonthOptions: YearMonthOption[] = [];
-	for (
-		let year = currentActualYear - 3;
-		year <= currentActualYear + 1;
-		year++
-	) {
+	for (let year = minYear; year <= maxYear; year++) {
 		for (let month = 1; month <= 12; month++) {
 			yearMonthOptions.push({
 				year,

--- a/app/(protected)/summary/_components/month-navigation-buttons.tsx
+++ b/app/(protected)/summary/_components/month-navigation-buttons.tsx
@@ -9,7 +9,7 @@ import {
 } from "@heroui/dropdown";
 import { IconChevronDown } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface MonthNavigationButtonsProps {
 	currentYear: number;
@@ -41,6 +41,8 @@ export function MonthNavigationButtons({
 	const [navigatingDirection, setNavigatingDirection] = useState<
 		"prev" | "next" | null
 	>(null);
+	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+	const menuRef = useRef<HTMLDivElement>(null);
 
 	// Generate year-month options (3 years back, 1 year forward)
 	const currentActualYear = new Date().getFullYear();
@@ -86,6 +88,47 @@ export function MonthNavigationButtons({
 	const isCurrentOption = (option: YearMonthOption) =>
 		option.year === currentYear && option.month === currentMonth;
 
+	const currentOptionIndex = yearMonthOptions.findIndex(
+		(option) => option.year === currentYear && option.month === currentMonth,
+	);
+
+	// Scroll to current option when dropdown opens
+	useEffect(() => {
+		if (!isDropdownOpen || currentOptionIndex === -1) return;
+
+		const timer = setTimeout(() => {
+			const currentKey = `${currentYear}-${currentMonth}`;
+			
+			// Find the dropdown menu element (HeroUI uses portal, so search document)
+			const menuElement = document.querySelector<HTMLElement>(
+				'[role="listbox"], [data-slot="base"] [class*="overflow"]',
+			);
+			
+			if (!menuElement) return;
+
+			// Find the current option by key attribute or text content
+			const currentItem = Array.from(
+				menuElement.querySelectorAll<HTMLElement>('[role="option"], li, button'),
+			).find((item) => {
+				const key = item.getAttribute('data-key') || 
+				           item.getAttribute('data-value') ||
+				           item.textContent?.trim();
+				return key === currentKey || 
+				       key?.includes(`${currentYear}年${monthNames[currentMonth - 1]}`);
+			});
+
+			if (!currentItem) return;
+
+			// Scroll the current item into view, centered if possible
+			currentItem.scrollIntoView({
+				behavior: 'instant',
+				block: 'center',
+			});
+		}, 150);
+
+		return () => clearTimeout(timer);
+	}, [isDropdownOpen, currentOptionIndex, currentYear, currentMonth, monthNames]);
+
 	return (
 		<div className="flex justify-between items-center mb-6">
 			<Button
@@ -102,31 +145,35 @@ export function MonthNavigationButtons({
 				{isNavigating && navigatingDirection === "prev" ? "読込中..." : "前月"}
 			</Button>
 
-			<Dropdown>
-				<DropdownTrigger>
-					<Button
-						variant="light"
-						endContent={<IconChevronDown size={16} />}
-						className="text-xl font-semibold px-0"
-					>
-						{currentLabel}
-					</Button>
-				</DropdownTrigger>
-				<DropdownMenu
-					aria-label="年月の選択"
-					className="max-h-[300px] overflow-y-auto"
-				>
-					{yearMonthOptions.map((option) => (
-						<DropdownItem
-							key={`${option.year}-${option.month}`}
-							onPress={() => handleYearMonthSelect(option.year, option.month)}
-							className={isCurrentOption(option) ? "bg-primary-50" : ""}
+			<div ref={menuRef}>
+				<Dropdown onOpenChange={setIsDropdownOpen}>
+					<DropdownTrigger>
+						<Button
+							variant="light"
+							endContent={<IconChevronDown size={16} />}
+							className="text-xl font-semibold px-0"
 						>
-							{option.label} {isCurrentOption(option) && "✓"}
-						</DropdownItem>
-					))}
-				</DropdownMenu>
-			</Dropdown>
+							{currentLabel}
+						</Button>
+					</DropdownTrigger>
+					<DropdownMenu
+						aria-label="年月の選択"
+						className="max-h-[300px] overflow-y-auto"
+						selectedKeys={[`${currentYear}-${currentMonth}`]}
+					>
+						{yearMonthOptions.map((option) => (
+							<DropdownItem
+								key={`${option.year}-${option.month}`}
+								onPress={() => handleYearMonthSelect(option.year, option.month)}
+								className={isCurrentOption(option) ? "bg-primary-50" : ""}
+								textValue={option.label}
+							>
+								{option.label} {isCurrentOption(option) && "✓"}
+							</DropdownItem>
+						))}
+					</DropdownMenu>
+				</Dropdown>
+			</div>
 
 			<Button
 				variant="bordered"

--- a/app/(protected)/summary/_components/month-navigation-buttons.tsx
+++ b/app/(protected)/summary/_components/month-navigation-buttons.tsx
@@ -9,7 +9,7 @@ import {
 } from "@heroui/dropdown";
 import { IconChevronDown } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 interface MonthNavigationButtonsProps {
 	currentYear: number;
@@ -42,7 +42,6 @@ export function MonthNavigationButtons({
 		"prev" | "next" | null
 	>(null);
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-	const menuRef = useRef<HTMLDivElement>(null);
 
 	// Generate year-month options (3 years back, 1 year forward)
 	const currentActualYear = new Date().getFullYear();
@@ -98,36 +97,47 @@ export function MonthNavigationButtons({
 
 		const timer = setTimeout(() => {
 			const currentKey = `${currentYear}-${currentMonth}`;
-			
+
 			// Find the dropdown menu element (HeroUI uses portal, so search document)
 			const menuElement = document.querySelector<HTMLElement>(
 				'[role="listbox"], [data-slot="base"] [class*="overflow"]',
 			);
-			
+
 			if (!menuElement) return;
 
 			// Find the current option by key attribute or text content
 			const currentItem = Array.from(
-				menuElement.querySelectorAll<HTMLElement>('[role="option"], li, button'),
+				menuElement.querySelectorAll<HTMLElement>(
+					'[role="option"], li, button',
+				),
 			).find((item) => {
-				const key = item.getAttribute('data-key') || 
-				           item.getAttribute('data-value') ||
-				           item.textContent?.trim();
-				return key === currentKey || 
-				       key?.includes(`${currentYear}年${monthNames[currentMonth - 1]}`);
+				const key =
+					item.getAttribute("data-key") ||
+					item.getAttribute("data-value") ||
+					item.textContent?.trim();
+				return (
+					key === currentKey ||
+					key?.includes(`${currentYear}年${monthNames[currentMonth - 1]}`)
+				);
 			});
 
 			if (!currentItem) return;
 
 			// Scroll the current item into view, centered if possible
 			currentItem.scrollIntoView({
-				behavior: 'instant',
-				block: 'center',
+				behavior: "instant",
+				block: "center",
 			});
 		}, 150);
 
 		return () => clearTimeout(timer);
-	}, [isDropdownOpen, currentOptionIndex, currentYear, currentMonth, monthNames]);
+	}, [
+		isDropdownOpen,
+		currentOptionIndex,
+		currentYear,
+		currentMonth,
+		monthNames,
+	]);
 
 	return (
 		<div className="flex justify-between items-center mb-6">
@@ -145,35 +155,33 @@ export function MonthNavigationButtons({
 				{isNavigating && navigatingDirection === "prev" ? "読込中..." : "前月"}
 			</Button>
 
-			<div ref={menuRef}>
-				<Dropdown onOpenChange={setIsDropdownOpen}>
-					<DropdownTrigger>
-						<Button
-							variant="light"
-							endContent={<IconChevronDown size={16} />}
-							className="text-xl font-semibold px-0"
-						>
-							{currentLabel}
-						</Button>
-					</DropdownTrigger>
-					<DropdownMenu
-						aria-label="年月の選択"
-						className="max-h-[300px] overflow-y-auto"
-						selectedKeys={[`${currentYear}-${currentMonth}`]}
+			<Dropdown onOpenChange={setIsDropdownOpen}>
+				<DropdownTrigger>
+					<Button
+						variant="light"
+						endContent={<IconChevronDown size={16} />}
+						className="text-xl font-semibold px-0"
 					>
-						{yearMonthOptions.map((option) => (
-							<DropdownItem
-								key={`${option.year}-${option.month}`}
-								onPress={() => handleYearMonthSelect(option.year, option.month)}
-								className={isCurrentOption(option) ? "bg-primary-50" : ""}
-								textValue={option.label}
-							>
-								{option.label} {isCurrentOption(option) && "✓"}
-							</DropdownItem>
-						))}
-					</DropdownMenu>
-				</Dropdown>
-			</div>
+						{currentLabel}
+					</Button>
+				</DropdownTrigger>
+				<DropdownMenu
+					aria-label="年月の選択"
+					className="max-h-[300px] overflow-y-auto"
+					selectedKeys={[`${currentYear}-${currentMonth}`]}
+				>
+					{yearMonthOptions.map((option) => (
+						<DropdownItem
+							key={`${option.year}-${option.month}`}
+							onPress={() => handleYearMonthSelect(option.year, option.month)}
+							className={isCurrentOption(option) ? "bg-primary-50" : ""}
+							textValue={option.label}
+						>
+							{option.label} {isCurrentOption(option) && "✓"}
+						</DropdownItem>
+					))}
+				</DropdownMenu>
+			</Dropdown>
 
 			<Button
 				variant="bordered"

--- a/app/(protected)/summary/_components/month-navigation-buttons.tsx
+++ b/app/(protected)/summary/_components/month-navigation-buttons.tsx
@@ -21,6 +21,12 @@ interface MonthNavigationButtonsProps {
 	monthNames: string[];
 }
 
+interface YearMonthOption {
+	year: number;
+	month: number;
+	label: string;
+}
+
 export function MonthNavigationButtons({
 	currentYear,
 	currentMonth,
@@ -36,15 +42,21 @@ export function MonthNavigationButtons({
 		"prev" | "next" | null
 	>(null);
 
-	// Generate year options (3 years back, 1 year forward)
+	// Generate year-month options (3 years back, 1 year forward)
 	const currentActualYear = new Date().getFullYear();
-	const yearOptions = [];
+	const yearMonthOptions: YearMonthOption[] = [];
 	for (
 		let year = currentActualYear - 3;
 		year <= currentActualYear + 1;
 		year++
 	) {
-		yearOptions.push(year);
+		for (let month = 1; month <= 12; month++) {
+			yearMonthOptions.push({
+				year,
+				month,
+				label: `${year}年${monthNames[month - 1]}`,
+			});
+		}
 	}
 
 	// Reset navigation state when year/month changes
@@ -58,23 +70,21 @@ export function MonthNavigationButtons({
 		setIsNavigating(true);
 		setNavigatingDirection(direction);
 
-		// Use router.push for faster navigation
 		router.push(href);
 
-		// Also set a timeout to reset state in case the navigation doesn't update props
 		setTimeout(() => {
 			setIsNavigating(false);
 			setNavigatingDirection(null);
 		}, 3000);
 	};
 
-	const handleYearSelect = (year: number) => {
-		router.push(`/summary?year=${year}&month=${currentMonth}`);
+	const handleYearMonthSelect = (year: number, month: number) => {
+		router.push(`/summary?year=${year}&month=${month}`);
 	};
 
-	const handleMonthSelect = (month: number) => {
-		router.push(`/summary?year=${currentYear}&month=${month}`);
-	};
+	const currentLabel = `${currentYear}年${monthNames[currentMonth - 1]}`;
+	const isCurrentOption = (option: YearMonthOption) =>
+		option.year === currentYear && option.month === currentMonth;
 
 	return (
 		<div className="flex justify-between items-center mb-6">
@@ -92,61 +102,31 @@ export function MonthNavigationButtons({
 				{isNavigating && navigatingDirection === "prev" ? "読込中..." : "前月"}
 			</Button>
 
-			<div className="flex items-center">
-				{/* 年選択 */}
-				<Dropdown>
-					<DropdownTrigger>
-						<Button
-							variant="light"
-							endContent={<IconChevronDown size={16} />}
-							className="text-xl font-semibold px-0"
-						>
-							{currentYear}年
-						</Button>
-					</DropdownTrigger>
-					<DropdownMenu
-						aria-label="年の選択"
-						className="max-h-[300px] overflow-y-auto"
+			<Dropdown>
+				<DropdownTrigger>
+					<Button
+						variant="light"
+						endContent={<IconChevronDown size={16} />}
+						className="text-xl font-semibold px-0"
 					>
-						{yearOptions.map((year) => (
-							<DropdownItem
-								key={`year-${year}`}
-								onPress={() => handleYearSelect(year)}
-								className={year === currentYear ? "bg-primary-50" : ""}
-							>
-								{year}年 {year === currentYear && "✓"}
-							</DropdownItem>
-						))}
-					</DropdownMenu>
-				</Dropdown>
-
-				{/* 月選択 */}
-				<Dropdown>
-					<DropdownTrigger>
-						<Button
-							variant="light"
-							endContent={<IconChevronDown size={16} />}
-							className="text-xl font-semibold px-0"
+						{currentLabel}
+					</Button>
+				</DropdownTrigger>
+				<DropdownMenu
+					aria-label="年月の選択"
+					className="max-h-[300px] overflow-y-auto"
+				>
+					{yearMonthOptions.map((option) => (
+						<DropdownItem
+							key={`${option.year}-${option.month}`}
+							onPress={() => handleYearMonthSelect(option.year, option.month)}
+							className={isCurrentOption(option) ? "bg-primary-50" : ""}
 						>
-							{monthNames[currentMonth - 1]}
-						</Button>
-					</DropdownTrigger>
-					<DropdownMenu
-						aria-label="月の選択"
-						className="max-h-[300px] overflow-y-auto"
-					>
-						{monthNames.map((monthName, index) => (
-							<DropdownItem
-								key={`month-${index + 1}`}
-								onPress={() => handleMonthSelect(index + 1)}
-								className={index + 1 === currentMonth ? "bg-primary-50" : ""}
-							>
-								{monthName} {index + 1 === currentMonth && "✓"}
-							</DropdownItem>
-						))}
-					</DropdownMenu>
-				</Dropdown>
-			</div>
+							{option.label} {isCurrentOption(option) && "✓"}
+						</DropdownItem>
+					))}
+				</DropdownMenu>
+			</Dropdown>
 
 			<Button
 				variant="bordered"


### PR DESCRIPTION
年と月の選択を1つのドロップダウンに統合し、連続的な年月選択を可能にします。

---
<a href="https://cursor.com/background-agent?bcId=bc-8d87a1f9-f319-4bbd-969f-bb9951ac7666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d87a1f9-f319-4bbd-969f-bb9951ac7666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces separate year and month pickers with a single year–month dropdown (spanning -3 to +1 years) that auto-scrolls to the current selection.
> 
> - **UI (summary navigation)** in `app/(protected)/summary/_components/month-navigation-buttons.tsx`:
>   - **Combined selector**: Replace separate year and month dropdowns with a single dropdown listing year–month options (3 years back to 1 year forward), labeled like `YYYY年<month>`.
>   - **Navigation update**: New `handleYearMonthSelect(year, month)` pushes `/summary?year=Y&month=M`; maintains prev/next buttons with loading state.
>   - **UX enhancements**: Auto-scroll the dropdown to the current year–month on open; highlights and marks the current option; shows current selection as button label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af75e60908a3cab11688b061d29e96db5881fce5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->