### PR TITLE
fix: ダッシュボードの予測計算を月額収支と一致させる

### DIFF
--- a/utils/predictions.ts
+++ b/utils/predictions.ts
@@ -151,8 +151,17 @@ export async function getMonthlyPredictions(): Promise<SavingsPrediction[]> {
 			monthOffset === 1
 				? { year: currentYear, month: currentMonth + 1 }
 				: {
-						year: new Date(currentYear, currentMonth + monthOffset - 1, 1).getFullYear(),
-						month: new Date(currentYear, currentMonth + monthOffset - 1, 1).getMonth() + 1,
+						year: new Date(
+							currentYear,
+							currentMonth + monthOffset - 1,
+							1,
+						).getFullYear(),
+						month:
+							new Date(
+								currentYear,
+								currentMonth + monthOffset - 1,
+								1,
+							).getMonth() + 1,
 					};
 
 		// 頻度とカスタム金額を考慮した定期収支を取得
@@ -171,7 +180,8 @@ export async function getMonthlyPredictions(): Promise<SavingsPrediction[]> {
 		const oneTimeNet = oneTimeTransactions.income - oneTimeTransactions.expense;
 
 		// 将来の貯蓄額を計算
-		const predictedAmount = currentBalance + accumulatedRecurringNet + oneTimeNet;
+		const predictedAmount =
+			currentBalance + accumulatedRecurringNet + oneTimeNet;
 
 		// 期間を文字列に変換（例: "1month", "2months"）
 		const periodStr =


### PR DESCRIPTION
## 概要
ダッシュボードの貯蓄予測グラフと月額収支ページの金額が一致しない問題を修正しました。

## 問題点
1. **月数計算が不正確**: `monthsBetween` を `(日数 / 30.44)` で計算していたため、月初に近い日付で0ヶ月と計算されていた
2. **頻度が考慮されていない**: `getMonthlyRecurringTotal()` は全ての定期取引を毎月として扱っていた（四半期・年次の頻度を無視）
3. **カスタム金額が使われていない**: `recurring_transaction_amounts` テーブルの月別カスタム金額が予測に反映されていなかった

## 修正内容
- `getMonthlyPredictions()` の月数計算を修正（不正確な30.44日計算を削除）
- 頻度(monthly/quarterly/yearly)を考慮した月別収支計算関数 `getRecurringTotalForMonth()` を追加
- `recurring_transaction_amounts` テーブルのカスタム金額を予測に反映
- 各月の定期取引を個別に計算して累積する方式に変更

## 変更ファイル
- `utils/predictions.ts`: 予測計算ロジックの修正
- `utils/supabase/recurring-transactions.ts`: 月別収支計算関数の追加

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks monthly savings predictions to accumulate per-month recurring totals (respecting frequency and custom amounts) and include one-time transactions up to each month start.
> 
> - **Predictions (`utils/predictions.ts`)**
>   - Rewrite `getMonthlyPredictions()` to compute month-by-month forecasts:
>     - Accumulates prior-month recurring net via `getRecurringTotalForMonth(year, month)`.
>     - Includes one-time transactions from today to each target month start.
>     - Removes approximate month-difference math; bases each point on exact month boundaries.
>   - Update imports to use `getRecurringTotalForMonth`.
> - **Recurring Transactions (`utils/supabase/recurring-transactions.ts`)**
>   - Add `getRecurringTotalForMonth(year, month, accountId?)`:
>     - Applies `monthly/quarterly/yearly` frequency via `isTransactionApplicableForMonth`.
>     - Uses per-month custom amounts from `recurring_transaction_amounts`, falling back to `default_amount`.
>   - Note in `getMonthlyRecurringTotal` that it ignores frequency (kept for compatibility).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e734214a42fd14162905489e2201de26865ea0e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->