### PR TITLE
Fix month-end balance calculation

### DIFF
--- a/app/(protected)/summary/_components/account-accordion.tsx
+++ b/app/(protected)/summary/_components/account-accordion.tsx
@@ -592,28 +592,39 @@ export const AccountAccordion = ({
 											new Date(b.transaction_date).getTime(),
 									);
 
-									// 初期残高を計算（優先順位: 月初残高テーブル > 前月計算値 > 現在残高）
+									// 選択した年月が現在の年月より後か判定
+									const selectedDate = new Date(
+										selectedYear,
+										selectedMonth - 1,
+										1,
+									);
+									const currentYearMonth = new Date(
+										currentDate.getFullYear(),
+										currentDate.getMonth(),
+										1,
+									);
+									const isSelectedDateAfterCurrent =
+										selectedDate > currentYearMonth;
+
+									// 初期残高を計算
+									// 将来月の場合は前月計算値を優先（最新の計算値）
+									// 過去・現在月は月初残高テーブルを優先（記録された値）
 									let initialBalance = account.balance; // デフォルト値
 
-									// 月初残高テーブルにデータがあればそれを優先的に使用
+									// 将来月で前月計算値がある場合はそれを優先
 									if (
+										isSelectedDateAfterCurrent &&
+										previousMonthBalances &&
+										previousMonthBalances[account.id] !== undefined
+									) {
+										initialBalance = previousMonthBalances[account.id];
+									}
+									// 過去・現在月は月初残高テーブルを優先
+									else if (
 										monthlyBalanceMap &&
 										monthlyBalanceMap[account.id] !== undefined
 									) {
 										initialBalance = monthlyBalanceMap[account.id];
-									}
-									// 月初残高テーブルにデータがなく、将来月の場合は前月計算値を使用
-									else if (
-										previousMonthBalances &&
-										previousMonthBalances[account.id] !== undefined &&
-										new Date(selectedYear, selectedMonth - 1, 1) >
-											new Date(
-												currentDate.getFullYear(),
-												currentDate.getMonth(),
-												1,
-											)
-									) {
-										initialBalance = previousMonthBalances[account.id];
 									}
 
 									// 基本残高から始めて、各トランザクション後の残高を計算

--- a/app/(protected)/summary/_components/account-accordion.tsx
+++ b/app/(protected)/summary/_components/account-accordion.tsx
@@ -512,15 +512,7 @@ export const AccountAccordion = ({
 									// 優先順位: 1. 月初残高テーブルの値, 2. 前月計算値
 									let initialBalanceValue: number | undefined;
 
-									// 月初残高テーブルにデータがあればそれを使用
 									if (
-										monthlyBalanceMap &&
-										monthlyBalanceMap[account.id] !== undefined
-									) {
-										initialBalanceValue = monthlyBalanceMap[account.id];
-									}
-									// 月初残高テーブルにデータがなく、選択月が現在より後の場合は前月計算値を使用
-									else if (
 										isSelectedDateAfterCurrent &&
 										previousMonthBalances &&
 										previousMonthBalances[account.id] !== undefined

--- a/app/(protected)/summary/actions.ts
+++ b/app/(protected)/summary/actions.ts
@@ -162,8 +162,11 @@ async function handleMonthlyBalances(
 	if (monthlyBalances) {
 		for (const balance of monthlyBalances) {
 			const numericBalance = Number(balance.balance);
-			monthlyBalanceMap[balance.account_id] = Number.isNaN(numericBalance) ? 0 : numericBalance;
-			}
+			monthlyBalanceMap[balance.account_id] = Number.isNaN(numericBalance)
+				? 0
+				: numericBalance;
+		}
+	}
 
 	return monthlyBalanceMap;
 }

--- a/app/(protected)/summary/actions.ts
+++ b/app/(protected)/summary/actions.ts
@@ -514,6 +514,19 @@ export async function updateOneTimeTransactionAmount(
 		throw new Error("認証が必要です");
 	}
 
+	// トランザクションの日付を取得
+	const { data: transaction, error: transactionError } = await supabase
+		.from("one_time_transactions")
+		.select("transaction_date")
+		.eq("id", transactionId)
+		.eq("user_id", user.id)
+		.single();
+
+	if (transactionError) {
+		console.error("一時的な収支の取得に失敗しました:", transactionError);
+		throw new Error("一時的な収支の取得に失敗しました");
+	}
+
 	// トランザクションを更新
 	const { error } = await supabase
 		.from("one_time_transactions")
@@ -524,6 +537,18 @@ export async function updateOneTimeTransactionAmount(
 	if (error) {
 		console.error("一時的な収支の更新に失敗しました:", error);
 		throw new Error("一時的な収支の更新に失敗しました");
+	}
+
+	// 取引の年月を計算して、その月以降の月初残高キャッシュを無効化
+	if (transaction?.transaction_date) {
+		const transactionDate = new Date(transaction.transaction_date);
+		const transactionYear = transactionDate.getFullYear();
+		const transactionMonth = transactionDate.getMonth() + 1;
+		await invalidateFutureMonthlyBalances(
+			supabase,
+			transactionYear,
+			transactionMonth,
+		);
 	}
 
 	// キャッシュをクリア
@@ -919,4 +944,36 @@ async function recordPreviousMonthBalances(
 		.insert(records);
 
 	if (error) throw error;
+}
+
+/**
+ * 指定した年月より後の月初残高キャッシュを無効化（削除）する
+ * 金額変更時に、その月以降のキャッシュを削除して再計算を促す
+ */
+export async function invalidateFutureMonthlyBalances(
+	supabase: SupabaseClient,
+	year: number,
+	month: number,
+): Promise<void> {
+	// ユーザーIDを取得
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		throw new Error("認証が必要です");
+	}
+
+	// 指定した年月より後のレコードを削除
+	// 条件: year > 指定年 OR (year = 指定年 AND month > 指定月)
+	const { error } = await supabase
+		.from("monthly_account_balances")
+		.delete()
+		.eq("user_id", user.id)
+		.or(`year.gt.${year},and(year.eq.${year},month.gt.${month})`);
+
+	if (error) {
+		console.error("月初残高キャッシュの無効化に失敗しました:", error);
+		throw new Error("月初残高キャッシュの無効化に失敗しました");
+	}
 }

--- a/app/(protected)/summary/actions.ts
+++ b/app/(protected)/summary/actions.ts
@@ -109,12 +109,13 @@ function calculateMonthlySummary(
 		// トランザクション配列を初期化
 		accountTransactions.set(account.id, []);
 
+		const numericBalance = Number(account.current_balance);
 		return {
 			id: account.id,
 			name: account.name,
 			income: 0,
 			expense: 0,
-			balance: account.current_balance,
+			balance: Number.isNaN(numericBalance) ? 0 : numericBalance,
 			transactions: [] as Transaction[],
 		};
 	});
@@ -461,13 +462,16 @@ async function calculateEndBalancesFromMonthlyData(
 			(a) => a.id === balance.account_id,
 		);
 
+		const baseBalance = Number(balance.balance);
+		const numericBalance = Number.isNaN(baseBalance) ? 0 : baseBalance;
+
 		if (!account) {
-			endBalances[balance.account_id] = balance.balance;
+			endBalances[balance.account_id] = numericBalance;
 			continue;
 		}
 
 		const monthlyChange = calculateMonthlyBalanceChange(account.transactions);
-		endBalances[balance.account_id] = balance.balance + monthlyChange;
+		endBalances[balance.account_id] = numericBalance + monthlyChange;
 	}
 
 	return endBalances;

--- a/app/(protected)/summary/actions.ts
+++ b/app/(protected)/summary/actions.ts
@@ -212,10 +212,13 @@ export async function getMonthlySummaryData(
 		let initialBalance = account.balance;
 		const prevBalance = previousMonthBalances?.[account.id];
 
-		if (monthlyBalanceMap[account.id] !== undefined) {
-			initialBalance = monthlyBalanceMap[account.id];
-		} else if (isSelectedDateAfterCurrent && prevBalance !== undefined) {
+		// 将来月で前月計算値がある場合はそれを優先（最新の計算値）
+		if (isSelectedDateAfterCurrent && prevBalance !== undefined) {
 			initialBalance = prevBalance;
+		}
+		// 過去・現在月は月初残高テーブルを優先（記録された値）
+		else if (monthlyBalanceMap[account.id] !== undefined) {
+			initialBalance = monthlyBalanceMap[account.id];
 		}
 
 		const finalBalance = calculateAccountFinalBalance(account, initialBalance);

--- a/app/(protected)/summary/balance-utils.ts
+++ b/app/(protected)/summary/balance-utils.ts
@@ -54,7 +54,8 @@ export async function fetchCurrentAccountBalances(
 
 	const balances: Record<string, number> = {};
 	for (const account of accounts) {
-		balances[account.id] = account.current_balance;
+		const numericBalance = Number(account.current_balance);
+		balances[account.id] = Number.isNaN(numericBalance) ? 0 : numericBalance;
 	}
 	return balances;
 }

--- a/app/(protected)/summary/page.tsx
+++ b/app/(protected)/summary/page.tsx
@@ -148,7 +148,10 @@ async function handleMonthlyBalances(
 	const monthlyBalanceMap: Record<string, number> = {};
 	if (monthlyBalances) {
 		for (const balance of monthlyBalances) {
-			monthlyBalanceMap[balance.account_id] = balance.balance;
+			const numericBalance = Number(balance.balance);
+			monthlyBalanceMap[balance.account_id] = Number.isNaN(numericBalance)
+				? 0
+				: numericBalance;
 		}
 	}
 
@@ -171,8 +174,8 @@ function calculateAccountFinalBalance(
 			new Date(a.transaction_date).getTime() -
 			new Date(b.transaction_date).getTime(),
 	);
-
-	let finalBalance = initialBalance;
+	const startingBalance = Number(initialBalance);
+	let finalBalance = Number.isNaN(startingBalance) ? 0 : startingBalance;
 	for (const transaction of sortedTransactions) {
 		finalBalance =
 			transaction.type === "income"

--- a/app/(protected)/transactions/recurring/actions.ts
+++ b/app/(protected)/transactions/recurring/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import type { Account } from "@/types/database";
 import { createClient } from "@/utils/supabase/server";
+import { invalidateFutureMonthlyBalances } from "../../summary/actions";
 import type {
 	MonthlyAmount,
 	RecurringTransaction,
@@ -183,6 +184,9 @@ export async function setAmountForMonth(
 				throw new Error(`月別金額の作成に失敗しました: ${insertError.message}`);
 		}
 	}
+
+	// 金額更新後、その月以降の月初残高キャッシュを無効化
+	await invalidateFutureMonthlyBalances(supabase, year, month);
 }
 
 /**


### PR DESCRIPTION
## Summary
- coerce monthly/account balances from Supabase numerics into real numbers before use
- ensure projected month-end balances use numeric arithmetic even when first transaction is income
- normalize balance fetching utilities so current balances and carryovers remain consistent across future months

## Testing
- [ ] Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves month-end balance accuracy and cache consistency across summary and recurring flows.
> 
> - Enforces numeric coercion for balances from Supabase (account/current, monthly balances, initial/final computations) and guards against NaN in `calculateAccountFinalBalance`
> - Adjusts initial balance precedence: for future months prefer `previousMonthBalances`; for past/current months prefer `monthlyBalanceMap` (applies in UI `account-accordion.tsx` and server `getMonthlySummaryData`)
> - Invalidates future `monthly_account_balances` cache after edits: new `invalidateFutureMonthlyBalances` utility; invoked on one-time transaction amount updates (by transaction date) and recurring monthly amount changes
> - Normalizes current balance fetching utilities to return numbers and uses numeric monthly balance values when deriving end-of-month balances
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c6f0f826294a0535a9f2c460cc68e340630a153. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->