### PR TITLE
perf: 貯蓄予想ページの遷移を高速化（60-100クエリ → 4クエリ）

### DIFF
--- a/app/(protected)/dashboard/actions.ts
+++ b/app/(protected)/dashboard/actions.ts
@@ -1,3 +1,5 @@
+import { calculateMonthlyBalanceChange } from "@/app/(protected)/summary/balance-utils";
+import type { Account } from "@/types/database";
 import { getUserAccounts, updateAccount } from "@/utils/supabase/accounts";
 import {
 	getUnprocessedOneTimeTransactions,
@@ -5,72 +7,56 @@ import {
 	markTransactionsAsProcessed,
 } from "@/utils/supabase/processed-transactions";
 
-export const updateAccountBalancesAction = async () => {
-	try {
-		// 今日の日付を取得し、翌日の0時0分0秒に設定（今日の取引も含めるため）
-		const today = new Date();
-		today.setDate(today.getDate() + 1);
-		today.setHours(0, 0, 0, 0);
+async function processAccountBalance(
+	account: Account,
+	today: Date,
+): Promise<Account> {
+	const currentDay = today.getDate();
+	const [unprocessedOneTimeTx, unprocessedRecurringTx] = await Promise.all([
+		getUnprocessedOneTimeTransactions(account.id, today),
+		getUnprocessedRecurringTransactions(account.id, currentDay),
+	]);
 
-		// 口座処理
-		const accounts = await getUserAccounts();
+	const balanceChange =
+		calculateMonthlyBalanceChange(unprocessedOneTimeTx) +
+		calculateMonthlyBalanceChange(unprocessedRecurringTx);
 
-		for (const account of accounts) {
-			// 未処理の臨時収支を取得
-			const unprocessedOneTimeTransactions =
-				await getUnprocessedOneTimeTransactions(account.id, today);
+	if (balanceChange === 0) return account;
 
-			// 未処理の定期的な収支を取得
-			const currentDay = today.getDate();
-			const unprocessedRecurringTransactions =
-				await getUnprocessedRecurringTransactions(account.id, currentDay);
+	const updated = await updateAccount(account.id, {
+		current_balance: account.current_balance + balanceChange,
+	});
 
-			// 残高変更を計算
-			const oneTimeTotal = unprocessedOneTimeTransactions.reduce(
-				(sum, tx) => sum + (tx.type === "income" ? tx.amount : -tx.amount),
-				0,
-			);
-
-			const recurringTotal = unprocessedRecurringTransactions.reduce(
-				(sum, tx) => sum + (tx.type === "income" ? tx.amount : -tx.amount),
-				0,
-			);
-
-			const balanceChange = oneTimeTotal + recurringTotal;
-
-			// 残高変更がある場合のみ更新
-			if (balanceChange !== 0) {
-				await updateAccount(account.id, {
-					current_balance: account.current_balance + balanceChange,
-				});
-
-				// 処理した臨時収支を処理済みとしてマーク
-				if (unprocessedOneTimeTransactions.length > 0) {
-					await markTransactionsAsProcessed(
-						unprocessedOneTimeTransactions,
-						"one_time",
-						account.id,
-					);
-				}
-
-				// 処理した定期的な収支を処理済みとしてマーク
-				if (unprocessedRecurringTransactions.length > 0) {
-					await markTransactionsAsProcessed(
-						unprocessedRecurringTransactions,
-						"recurring",
-						account.id,
-					);
-				}
-			}
-		}
-
-		return { success: true, message: "口座残高を更新しました" };
-	} catch (error) {
-		console.error("Error updating account balances:", error);
-		return {
-			success: false,
-			message:
-				error instanceof Error ? error.message : "口座残高の更新に失敗しました",
-		};
+	if (unprocessedOneTimeTx.length > 0) {
+		await markTransactionsAsProcessed(
+			unprocessedOneTimeTx,
+			"one_time",
+			account.id,
+		);
 	}
-};
+	if (unprocessedRecurringTx.length > 0) {
+		await markTransactionsAsProcessed(
+			unprocessedRecurringTx,
+			"recurring",
+			account.id,
+		);
+	}
+
+	return updated;
+}
+
+/**
+ * 全口座の残高を未処理取引で更新し、更新後のアカウント一覧を返す
+ */
+export async function updateAccountBalancesAction(): Promise<Account[]> {
+	// 今日の日付を取得し、翌日の0時0分0秒に設定（今日の取引も含めるため）
+	const today = new Date();
+	today.setDate(today.getDate() + 1);
+	today.setHours(0, 0, 0, 0);
+
+	const accounts = await getUserAccounts();
+
+	return Promise.all(
+		accounts.map((account) => processAccountBalance(account, today)),
+	);
+}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -5,9 +5,8 @@ import { updateAccountBalancesAction } from "./actions";
 import DashboardLoading from "./loading";
 
 async function DashboardData() {
-	await updateAccountBalancesAction();
-
-	const monthlyPredictions = await getMonthlyPredictions();
+	const updatedAccounts = await updateAccountBalancesAction();
+	const monthlyPredictions = await getMonthlyPredictions(updatedAccounts);
 
 	return <Dashboard monthlyPredictions={monthlyPredictions} />;
 }

--- a/utils/predictions.ts
+++ b/utils/predictions.ts
@@ -1,9 +1,17 @@
-import { getMonthlySummaryData } from "@/app/(protected)/summary/actions";
+import { format } from "date-fns";
 import { incrementMonth } from "@/app/(protected)/summary/balance-utils";
-import type { PredictionPeriod, SavingsPrediction } from "@/types/database";
+import type {
+	Account,
+	OneTimeTransaction,
+	PredictionPeriod,
+	RecurringTransaction,
+	RecurringTransactionAmount,
+	SavingsPrediction,
+} from "@/types/database";
 import { getTotalBalance, getUserAccounts } from "@/utils/supabase/accounts";
 import { getOneTimeTransactionsTotal } from "@/utils/supabase/one-time-transactions";
 import { getMonthlyRecurringTotal } from "@/utils/supabase/recurring-transactions";
+import { createClient } from "@/utils/supabase/server";
 
 /**
  * 指定した月数後の日付を取得する
@@ -124,49 +132,190 @@ export async function getAllPredictions(): Promise<SavingsPrediction[]> {
 	return predictions;
 }
 
-/**
- * 1か月ごとの貯蓄額を予測する（翌月から12ヶ月先まで）
- * 各月の月末見込残高を予測（月次収支と同じ計算ロジックを使用）
- */
-export async function getMonthlyPredictions(): Promise<SavingsPrediction[]> {
-	const today = new Date();
-	const currentYear = today.getFullYear();
-	const currentMonth = today.getMonth() + 1; // 1-12
+type PredictionSeedData = {
+	accounts: Account[];
+	recurringTransactions: RecurringTransaction[];
+	oneTimeTransactions: OneTimeTransaction[];
+	recurringAmounts: RecurringTransactionAmount[];
+	currentMonthBalances: Record<string, number>;
+};
+
+// month は1-12。date-fns の new Date(year, month-1, day) で構築して format する
+function fmtDate(year: number, month: number, day: number): string {
+	return format(new Date(year, month - 1, day), "yyyy-MM-dd");
+}
+
+function getPredictionEndYearMonth(
+	currentYear: number,
+	currentMonth: number,
+): { year: number; month: number } {
+	let y = currentYear;
+	let m = currentMonth;
+	for (let i = 0; i < 12; i++) {
+		({ year: y, month: m } = incrementMonth(y, m));
+	}
+	return { year: y, month: m };
+}
+
+async function fetchPredictionSeedData(
+	accounts: Account[],
+	currentYear: number,
+	currentMonth: number,
+): Promise<PredictionSeedData> {
+	const supabase = await createClient();
+	const end = getPredictionEndYearMonth(currentYear, currentMonth);
+
+	// month-1 で月末日 (new Date(y, m, 0) は月末) → format
+	const startDate = fmtDate(currentYear, currentMonth, 1);
+	const endDate = format(new Date(end.year, end.month, 0), "yyyy-MM-dd");
+
+	const [recurringTx, oneTimeTx, recurringAmounts, monthlyBal] =
+		await Promise.all([
+			supabase.from("recurring_transactions").select("*"),
+			supabase
+				.from("one_time_transactions")
+				.select("*")
+				.gte("transaction_date", startDate)
+				.lte("transaction_date", endDate),
+			supabase
+				.from("recurring_transaction_amounts")
+				.select("*")
+				.gte("year", currentYear)
+				.lte("year", end.year),
+			supabase
+				.from("monthly_account_balances")
+				.select("account_id, balance")
+				.eq("year", currentYear)
+				.eq("month", currentMonth),
+		]);
+
+	const currentMonthBalances: Record<string, number> = {};
+	for (const bal of monthlyBal.data ?? []) {
+		currentMonthBalances[bal.account_id] = bal.balance;
+	}
+
+	return {
+		accounts,
+		recurringTransactions: recurringTx.data ?? [],
+		oneTimeTransactions: oneTimeTx.data ?? [],
+		recurringAmounts: recurringAmounts.data ?? [],
+		currentMonthBalances,
+	};
+}
+
+// "YEAR-MONTH" -> (txId -> amount) の2段 Map を1回だけ構築してキャッシュ
+type CustomAmountsCache = Map<string, Map<string, number>>;
+
+function buildCustomAmountsCache(
+	recurringAmounts: RecurringTransactionAmount[],
+): CustomAmountsCache {
+	const cache: CustomAmountsCache = new Map();
+	for (const ra of recurringAmounts) {
+		const key = `${ra.year}-${ra.month}`;
+		const monthMap = cache.get(key) ?? new Map<string, number>();
+		monthMap.set(ra.recurring_transaction_id, ra.amount);
+		cache.set(key, monthMap);
+	}
+	return cache;
+}
+
+function calcMonthlyChanges(
+	seed: PredictionSeedData,
+	customAmountsCache: CustomAmountsCache,
+	year: number,
+	month: number,
+): Record<string, number> {
+	const changes: Record<string, number> = {};
+	for (const account of seed.accounts) {
+		changes[account.id] = 0;
+	}
+
+	const customAmounts =
+		customAmountsCache.get(`${year}-${month}`) ?? new Map<string, number>();
+
+	for (const tx of seed.recurringTransactions) {
+		if (!(tx.account_id in changes)) continue;
+		const amount = customAmounts.get(tx.id) ?? tx.default_amount;
+		changes[tx.account_id] += tx.type === "income" ? amount : -amount;
+	}
+
+	const monthStart = fmtDate(year, month, 1);
+	const monthEnd = format(new Date(year, month, 0), "yyyy-MM-dd");
+
+	for (const tx of seed.oneTimeTransactions) {
+		if (tx.transaction_date < monthStart || tx.transaction_date > monthEnd)
+			continue;
+		if (!(tx.account_id in changes)) continue;
+		changes[tx.account_id] += tx.type === "income" ? tx.amount : -tx.amount;
+	}
+
+	return changes;
+}
+
+function applyChanges(
+	balances: Record<string, number>,
+	changes: Record<string, number>,
+): void {
+	for (const id in changes) {
+		balances[id] = (balances[id] ?? 0) + changes[id];
+	}
+}
+
+function buildPredictions(
+	seed: PredictionSeedData,
+	currentYear: number,
+	currentMonth: number,
+): SavingsPrediction[] {
+	const balances: Record<string, number> = {};
+	for (const account of seed.accounts) {
+		balances[account.id] =
+			seed.currentMonthBalances[account.id] ?? account.current_balance;
+	}
+
+	const cache = buildCustomAmountsCache(seed.recurringAmounts);
+
+	applyChanges(
+		balances,
+		calcMonthlyChanges(seed, cache, currentYear, currentMonth),
+	);
 
 	const predictions: SavingsPrediction[] = [];
+	let { year, month } = incrementMonth(currentYear, currentMonth);
 
-	// 翌月から12ヶ月先までの予測を計算
-	let { year: targetYear, month: targetMonth } = incrementMonth(
+	for (let i = 1; i <= 12; i++) {
+		applyChanges(balances, calcMonthlyChanges(seed, cache, year, month));
+
+		const total = Object.values(balances).reduce((sum, b) => sum + b, 0);
+		const date = fmtDate(year, month, 1);
+		const period = (i === 1 ? "1month" : `${i}months`) as PredictionPeriod;
+
+		predictions.push({ period, amount: total, date });
+
+		({ year, month } = incrementMonth(year, month));
+	}
+
+	return predictions;
+}
+
+/**
+ * 1か月ごとの貯蓄額を予測する（翌月から12ヶ月先まで）
+ * 各月の月末見込残高を予測（4クエリ一括取得 → メモリ上で前方伝播計算）
+ */
+export async function getMonthlyPredictions(
+	accounts?: Account[],
+): Promise<SavingsPrediction[]> {
+	const today = new Date();
+	const currentYear = today.getFullYear();
+	const currentMonth = today.getMonth() + 1;
+
+	const resolvedAccounts = accounts ?? (await getUserAccounts());
+	const seed = await fetchPredictionSeedData(
+		resolvedAccounts,
 		currentYear,
 		currentMonth,
 	);
 
-	for (let i = 1; i <= 12; i++) {
-		// 対象月の月末見込残高を取得
-		const { totalEndOfMonthBalance } = await getMonthlySummaryData(
-			targetYear,
-			targetMonth,
-		);
-
-		// 対象月の1日を作成（予測日付として使用）
-		const targetDate = new Date(targetYear, targetMonth - 1, 1);
-
-		// 期間を文字列に変換
-		const periodStr = i === 1 ? "1month" : (`${i}months` as PredictionPeriod);
-
-		predictions.push({
-			period: periodStr,
-			amount: totalEndOfMonthBalance,
-			date: targetDate.toISOString().split("T")[0],
-		});
-
-		// 次の月へ
-		const next = incrementMonth(targetYear, targetMonth);
-		targetYear = next.year;
-		targetMonth = next.month;
-	}
-
-	return predictions;
+	return buildPredictions(seed, currentYear, currentMonth);
 }
 
 /**


### PR DESCRIPTION
## Summary

- `getMonthlyPredictions()` を全面書き換え。12ヶ月分を1月ずつ直列クエリしていた処理（60〜100+クエリ）を、4クエリ並列一括取得＋メモリ上での前方伝播計算に置き換え
- `updateAccountBalancesAction()` の返り値を `Account[]` に変更し、更新後アカウントを予測計算に直接渡すことで `getUserAccounts()` の二重呼び出しを解消
- アカウントごとの残高更新処理を `Promise.all` で並列化
- カスタム金額マップを毎回スキャン（13回）→ 1回だけキャッシュ構築に変更
- `recurring_transaction_amounts` クエリに年フィルタを追加（全件取得 → 予測期間内のみ）

## Background

月次収支 → 貯蓄予想の遷移で約2秒の遅延が発生していた。根本原因は `getMonthlySummaryData()` を12回直列 `await` しており、各呼び出しで副作用（`carryoverMonthlyBalances` 等のDB書き込み）が走るため単純な `Promise.all` 並列化もできない構造だった。

詳細な調査・設計は `plan.md` 参照。

## Test plan

- [ ] 月次収支ページ → 貯蓄予想ページへの遷移が体感的に速くなっていることを確認
- [ ] 貯蓄予想の12ヶ月グラフが正しく表示されること
- [ ] 口座残高が正しく更新されること（未処理取引が反映されること）
- [ ] `pnpm typecheck && pnpm check` がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)