### PR TITLE
refactor(phase2-1): Supabase クライアントの型付けと requireUser ヘルパー

### DIFF
--- a/app/(protected)/summary/_lib/calculations.ts
+++ b/app/(protected)/summary/_lib/calculations.ts
@@ -100,7 +100,9 @@ export function calculateMonthlySummary(
 		const formattedTransactionDate = format(transactionDate, "yyyy-MM-dd");
 
 		// 当月の日付が定期的な収支の日付以上の場合のみ集計
-		const accountSummary = accountMap.get(transaction.account_id);
+		const accountSummary = transaction.account_id
+			? accountMap.get(transaction.account_id)
+			: undefined;
 		if (accountSummary) {
 			// 特定の年月のカスタム金額があればそれを使用し、なければデフォルト金額を使用
 			const customAmount = recurringAmountsMap.get(transaction.id);

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -164,7 +164,9 @@ function calculateMonthlySummary(
 			.split("T")[0];
 
 		// 当月の日付が定期的な収支の日付以上の場合のみ集計
-		const accountSummary = accountMap.get(transaction.account_id);
+		const accountSummary = transaction.account_id
+			? accountMap.get(transaction.account_id)
+			: undefined;
 		if (accountSummary) {
 			if (transaction.type === "income") {
 				accountSummary.income += transaction.amount;

--- a/types/database.ts
+++ b/types/database.ts
@@ -15,7 +15,8 @@ export type FrequencyType = "monthly" | "quarterly" | "yearly";
 export type RecurringTransaction = {
 	id: string;
 	user_id: string;
-	account_id: string;
+	// DB スキーマ上 NULL 許容（口座未紐付けの住民税取引などで null になる）
+	account_id: string | null;
 	amount: number;
 	default_amount: number;
 	type: TransactionType;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,0 +1,138 @@
+import type {
+	Account,
+	OneTimeTransaction,
+	RecurringTransaction,
+	RecurringTransactionAmount,
+	ResidentTaxPeriodSetting,
+	ResidentTaxSetting,
+} from "./database";
+
+export type Json =
+	| string
+	| number
+	| boolean
+	| null
+	| { [key: string]: Json | undefined }
+	| Json[];
+
+export type ProcessedTransaction = {
+	id: string;
+	transaction_id: string;
+	transaction_type: "one_time" | "recurring";
+	account_id: string;
+	processed_at: string;
+};
+
+export type MonthlyAccountBalance = {
+	id: string;
+	account_id: string;
+	user_id: string;
+	year: number;
+	month: number;
+	balance: number;
+	created_at: string;
+	updated_at: string;
+};
+
+/**
+ * supabase/migrations のスキーマから導出したテーブル定義。
+ * Row はドメイン型（types/database.ts）を単一の真実として参照する。
+ * DB 側で自動生成されるカラムは Insert で省略可能にしている。
+ */
+type TableDef<Row, Generated extends keyof Row> = {
+	Row: Row;
+	Insert: Omit<Row, Generated> & Partial<Pick<Row, Generated>>;
+	Update: Partial<Row>;
+	Relationships: [];
+};
+
+type GeneratedColumns = "id" | "created_at" | "updated_at";
+
+export type Database = {
+	public: {
+		Tables: {
+			accounts: TableDef<Account, GeneratedColumns | "sort_order">;
+			recurring_transactions: TableDef<
+				RecurringTransaction,
+				| GeneratedColumns
+				| "frequency"
+				| "is_transfer"
+				| "destination_account_id"
+				| "transfer_pair_id"
+				| "month_of_year"
+				| "day_of_year"
+				| "billing_day"
+				| "payment_day"
+				| "is_resident_tax"
+			>;
+			one_time_transactions: TableDef<
+				OneTimeTransaction,
+				| GeneratedColumns
+				| "is_transfer"
+				| "destination_account_id"
+				| "transfer_pair_id"
+			>;
+			recurring_transaction_amounts: TableDef<
+				RecurringTransactionAmount,
+				GeneratedColumns
+			>;
+			processed_transactions: TableDef<
+				ProcessedTransaction,
+				"id" | "processed_at"
+			>;
+			monthly_account_balances: TableDef<
+				MonthlyAccountBalance,
+				GeneratedColumns
+			>;
+			resident_tax_settings: TableDef<ResidentTaxSetting, GeneratedColumns>;
+			resident_tax_periods: TableDef<
+				ResidentTaxPeriodSetting,
+				| GeneratedColumns
+				| "target_recurring_transaction_id"
+				| "created_recurring_transaction_id"
+			>;
+		};
+		Views: Record<string, never>;
+		Functions: {
+			create_one_time_transfer: {
+				Args: {
+					p_user_id: string;
+					p_source_account_id: string;
+					p_destination_account_id: string;
+					p_name: string;
+					p_amount: number;
+					p_transaction_date: string;
+					p_description?: string | null;
+					p_transfer_pair_id?: string | null;
+				};
+				Returns: Json;
+			};
+			update_one_time_transfer_pair: {
+				Args: Record<string, Json | null | undefined>;
+				Returns: Json;
+			};
+			delete_one_time_transfer_pair: {
+				Args: Record<string, Json | null | undefined>;
+				Returns: Json;
+			};
+			create_recurring_transfer: {
+				Args: {
+					p_user_id: string;
+					p_source_account_id: string;
+					p_destination_account_id: string;
+					p_name: string;
+					p_amount: number;
+					p_default_amount: number;
+					p_day_of_month: number;
+					p_frequency: string;
+					p_month_of_year?: number | null;
+					p_description?: string | null;
+					p_transfer_pair_id?: string | null;
+				};
+				Returns: Json;
+			};
+		};
+		Enums: Record<string, never>;
+		CompositeTypes: Record<string, never>;
+	};
+};

--- a/utils/supabase/accounts.ts
+++ b/utils/supabase/accounts.ts
@@ -1,4 +1,5 @@
 import type { Account } from "@/types/database";
+import { requireUser } from "@/utils/supabase/helpers";
 import { createClient } from "@/utils/supabase/server";
 
 /**
@@ -17,7 +18,7 @@ export async function getUserAccounts(): Promise<Account[]> {
 		throw new Error("口座情報の取得に失敗しました");
 	}
 
-	return data as Account[];
+	return data;
 }
 
 /**
@@ -43,7 +44,7 @@ export async function getAccountById(
 		throw new Error("口座情報の取得に失敗しました");
 	}
 
-	return data as Account;
+	return data;
 }
 
 /**
@@ -55,13 +56,7 @@ export async function createAccount(
 ): Promise<Account> {
 	const supabase = await createClient();
 
-	// 現在のユーザーIDを取得
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
-	if (!user) {
-		throw new Error("ユーザーが認証されていません");
-	}
+	const user = await requireUser(supabase);
 
 	const { data, error } = await supabase
 		.from("accounts")
@@ -102,7 +97,7 @@ export async function createAccount(
 		}
 	}
 
-	return data as Account;
+	return data;
 }
 
 /**
@@ -129,7 +124,7 @@ export async function updateAccount(
 		throw new Error("口座情報の更新に失敗しました");
 	}
 
-	return data as Account;
+	return data;
 }
 
 /**

--- a/utils/supabase/client.ts
+++ b/utils/supabase/client.ts
@@ -1,4 +1,5 @@
 import { createBrowserClient } from "@supabase/ssr";
+import type { Database } from "@/types/supabase";
 
 export function createClient() {
 	const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -8,5 +9,5 @@ export function createClient() {
 		throw new Error("Missing Supabase environment variables");
 	}
 
-	return createBrowserClient(supabaseUrl, supabaseKey);
+	return createBrowserClient<Database>(supabaseUrl, supabaseKey);
 }

--- a/utils/supabase/helpers.ts
+++ b/utils/supabase/helpers.ts
@@ -1,0 +1,22 @@
+import type { SupabaseClient, User } from "@supabase/supabase-js";
+import type { Database } from "@/types/supabase";
+
+export type TypedSupabaseClient = SupabaseClient<Database>;
+
+/**
+ * 認証済みユーザーを取得する。未認証の場合は例外を投げる。
+ * データ層の各関数で繰り返されていた認証チェックの共通化。
+ */
+export async function requireUser(
+	supabase: TypedSupabaseClient,
+): Promise<User> {
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		throw new Error("ユーザーが認証されていません");
+	}
+
+	return user;
+}

--- a/utils/supabase/one-time-transactions.ts
+++ b/utils/supabase/one-time-transactions.ts
@@ -168,9 +168,12 @@ export async function createOneTimeTransfer(
 		throw new Error("送金データの作成に失敗しました");
 	}
 
-	const sourceTransaction = data.source_transaction as OneTimeTransaction;
-	const destinationTransaction =
-		data.destination_transaction as OneTimeTransaction;
+	const result = data as {
+		source_transaction: OneTimeTransaction;
+		destination_transaction: OneTimeTransaction;
+	};
+	const sourceTransaction = result.source_transaction;
+	const destinationTransaction = result.destination_transaction;
 
 	return { sourceTransaction, destinationTransaction };
 }
@@ -243,18 +246,15 @@ export async function updateOneTimeTransaction(
 	}
 
 	// 通常の取引の場合は従来通りの処理
-	const updatedData = { ...updates };
+	const { transaction_date, ...restUpdates } = updates;
+	const updatedData: Partial<OneTimeTransaction> = { ...restUpdates };
 
 	// 日付形式を変換
-	if (updates.transaction_date) {
-		if (updates.transaction_date instanceof Date) {
-			updatedData.transaction_date = updates.transaction_date
-				.toISOString()
-				.split("T")[0];
-		} else {
-			// 既に文字列形式の場合はそのまま使用
-			updatedData.transaction_date = updates.transaction_date;
-		}
+	if (transaction_date) {
+		updatedData.transaction_date =
+			transaction_date instanceof Date
+				? transaction_date.toISOString().split("T")[0]
+				: transaction_date;
 	}
 
 	const { data, error } = await supabase

--- a/utils/supabase/recurring-transactions.ts
+++ b/utils/supabase/recurring-transactions.ts
@@ -159,9 +159,12 @@ export async function createRecurringTransfer(
 		throw new Error("定期送金データの作成に失敗しました");
 	}
 
-	const sourceTransaction = data.source_transaction as RecurringTransaction;
-	const destinationTransaction =
-		data.destination_transaction as RecurringTransaction;
+	const result = data as {
+		source_transaction: RecurringTransaction;
+		destination_transaction: RecurringTransaction;
+	};
+	const sourceTransaction = result.source_transaction;
+	const destinationTransaction = result.destination_transaction;
 
 	return { sourceTransaction, destinationTransaction };
 }

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import type { Database } from "@/types/supabase";
 
 export async function createClient() {
 	const cookieStore = await cookies();
@@ -10,7 +11,7 @@ export async function createClient() {
 		throw new Error("Missing Supabase environment variables");
 	}
 
-	return createServerClient(supabaseUrl, supabaseKey, {
+	return createServerClient<Database>(supabaseUrl, supabaseKey, {
 		cookies: {
 			getAll() {
 				return cookieStore.getAll();


### PR DESCRIPTION
## 概要

[リファクタリング計画](https://github.com/irishkooky/asset-management-app/blob/refactor/p0-safety-net/docs/REFACTORING_PLAN.md) の **Phase 2(データアクセス層の再構築)** の第1弾です。

> **Note**: #135 (Phase 1) の上に積んだ stacked PR です。マージ順: #134 → #135 → 本PR

## 変更内容

### 1. `Database` スキーマ型の導入(`types/supabase.ts`)
- `supabase/migrations` の SQL から導出。Row 型は既存ドメイン型(`types/database.ts`)を単一の真実として参照
- `createServerClient<Database>` / `createBrowserClient<Database>` でクライアントを型付け

### 2. 型付けで炙り出された潜在的型不整合の修正
- **`RecurringTransaction.account_id` は実は NULL 許容**: DB スキーマに NOT NULL がなく、住民税の自動作成取引は `account_id: null` で insert していた。ドメイン型を `string | null` に修正し、集計ループに null ガードを追加(null は従来も Map 不一致で暗黙にスキップされており挙動不変)
- `updateOneTimeTransaction` の update ペイロードを型安全に(`Date` 混入を型レベルで排除)
- RPC の JSON 戻り値をプロパティ単位のキャストから単一キャストに

### 3. `requireUser` ヘルパー(`utils/supabase/helpers.ts`)
- 5ファイルに散在する認証チェックボイラープレートの共通化(本PRでは accounts.ts に適用、残りは後続PR)

### 4. accounts.ts をモデルケースとして移行
- 手動キャスト(`as Account`)を全廃 — 型付きクライアントがクエリから型を導出

後続PRで one-time / recurring / resident-tax / processed を同パターンに移行します。

## 検証

- `pnpm typecheck` ✅ / `pnpm check` ✅ / `pnpm test` ✅ (33 passed) / `pnpm build` ✅ / `pnpm knip` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)